### PR TITLE
Add a few code pages for some East Asian languages.

### DIFF
--- a/gui/controls.cpp
+++ b/gui/controls.cpp
@@ -404,6 +404,11 @@ CodePageComboBox::CodePageComboBox(QWidget *parent):
     addCodecName(tr("Windows 1257"), "windows-1257");
     addCodecName(tr("Windows 1258"), "windows-1258");
 
+    insertSeparator(9999);
+    addCodecName(tr("Simplified Chinese (GB18030)"), "GB18030");
+    addCodecName(tr("Traditional Chinese (BIG5)"), "Big5");
+    addCodecName(tr("Japanese (CP932)"), "windows-31j");
+
 }
 
 


### PR DESCRIPTION
Sometimes the auto detection of code page does not work, I still need to specify a correct code page explicitly. However, the options are limited, so I added a few code pages for some East Asian languages.

Before:
![Before](https://imgur.com/F9SjjUY.png)
After:
![After](https://imgur.com/vRGLZhS.png)