### PR TITLE
Fix for static progress bar

### DIFF
--- a/gui/trackviewdelegate.cpp
+++ b/gui/trackviewdelegate.cpp
@@ -299,7 +299,7 @@ void TrackViewDelegate::paintTrack(QPainter *painter, const QStyleOptionViewItem
         opt.progress = progress;
         opt.text     = QString("%1 %2%").arg(txt).arg(opt.progress);
 
-        QApplication::style()->drawControl(QStyle::CE_ProgressBarContents, &opt, painter);
+        QApplication::style()->drawControl(QStyle::CE_ProgressBar, &opt, painter);
         QApplication::style()->drawControl(QStyle::CE_ProgressBarLabel, &opt, painter);
     }
     else {


### PR DESCRIPTION
With QStyle::CE_ProgressBarContents the progress bars never show any actual progress (just text progress percentage).  This patch switches to QStyle::CE_ProgressBar to make the progress bar actually animated.

Before:
![b4](https://user-images.githubusercontent.com/43704682/153662222-4751dc4a-51fb-4e68-bfa0-87470f89316e.png)

After:
![af](https://user-images.githubusercontent.com/43704682/153662253-ffeb8bc3-4198-43ba-b612-acb8c084231f.png)
