### PR TITLE
CMake: Ensure .desktop file installed location matches the metainfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,7 @@ function(CREATE_FLATPAK_METAINFO_FILE _IN_FILE _OUT_FILE)
     configure_file(${_IN_FILE} ${_OUT_FILE} @ONLY)
 endfunction()
 
-CREATE_DESKTOP_FILE(misc/${PROJECT_NAME}.desktop ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.desktop translations/*.desktop)
+CREATE_DESKTOP_FILE(misc/${PROJECT_NAME}.desktop ${CMAKE_CURRENT_BINARY_DIR}/com.github.Flacon.desktop translations/*.desktop)
 CREATE_FLATPAK_METAINFO_FILE(misc/com.github.Flacon.metainfo.xml.in ${CMAKE_CURRENT_BINARY_DIR}/com.github.Flacon.metainfo.xml)
 
 # Man page **************************************


### PR DESCRIPTION
`misc/com.github.Flacon.metainfo.xml.in` defines the <launchable> tag as:

`<launchable type="desktop-id">com.github.Flacon.desktop</launchable>`

If the installed location and the desktop-id don't match then appstream-builder is unable to find an icon for the project, causing the appstream generation to fail.

Fixes appstream generation on Solus and probably other distros.

Test case:

`file flacon-7.0.1-12-1-x86_64.eopkg`
`appstream-builder --packages-dir=. --include-failed`

Verify that flacon no longer shows up in the `example-failed.xml.gz` file.