### PR TITLE
refactor: replace non-empty QString constructors with QStringLiteral()

### DIFF
--- a/consoleout.cpp
+++ b/consoleout.cpp
@@ -95,11 +95,11 @@ void ConsoleOut::printStatistic()
     QString str;
 
     if (h)
-        str = QString("Encoding time %4h %3m %2s [%1 sec]").arg(duration).arg(s).arg(m).arg(h);
+        str = QStringLiteral("Encoding time %4h %3m %2s [%1 sec]").arg(duration).arg(s).arg(m).arg(h);
     else if (m)
-        str = QString("Encoding time %3m %2s [%1 sec]").arg(duration).arg(s).arg(m);
+        str = QStringLiteral("Encoding time %3m %2s [%1 sec]").arg(duration).arg(s).arg(m);
     else
-        str = QString("Encoding time %1 sec").arg(duration);
+        str = QStringLiteral("Encoding time %1 sec").arg(duration);
 
     QTextStream(stdout) << str << "\n";
 }

--- a/converter/converter.cpp
+++ b/converter/converter.cpp
@@ -220,10 +220,10 @@ bool Converter::validate(const Jobs &jobs, const Profile &profile)
 
     QString s;
     foreach (QString e, errors) {
-        s += QString("<li style='margin-top: 4px;'> %1</li>").arg(e);
+        s += QStringLiteral("<li style='margin-top: 4px;'> %1</li>").arg(e);
     }
 
-    Messages::error(QString("<html>%1<ul>%2</ul></html>")
+    Messages::error(QStringLiteral("<html>%1<ul>%2</ul></html>")
                             .arg(tr("Conversion is not possible:"))
                             .arg(s));
 

--- a/converter/cuecreator.cpp
+++ b/converter/cuecreator.cpp
@@ -124,7 +124,7 @@ void CueCreator::writeTags(QIODevice *out, const Track *track) const
     CueFlags flags(track->tag(TagId::Flags));
     flags.preEmphasis = false; // We already deephasis audio, so we reset this flag
     if (!flags.isEmpty()) {
-        writeLine(out, QString("    FLAGS %1").arg(flags.toString()));
+        writeLine(out, QStringLiteral("    FLAGS %1").arg(flags.toString()));
     }
 
     writeTrackTag(out, track, "ISRC %1", TagId::ISRC);
@@ -172,45 +172,45 @@ void CueCreator::write(QIODevice *out)
         if (i == 0) {
             if (index0.isNull() || index0 == index1) {
                 // No pregap ....................
-                writeLine(out, QString("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFileName(track)).fileName()));
-                writeLine(out, QString("TRACK %1 AUDIO").arg(i + 1, 2, 10, QChar('0')));
+                writeLine(out, QStringLiteral("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFileName(track)).fileName()));
+                writeLine(out, QStringLiteral("TRACK %1 AUDIO").arg(i + 1, 2, 10, QChar('0')));
                 writeTags(out, track);
-                writeLine(out, QString("INDEX 01 %1").arg("00:00:00"));
+                writeLine(out, QStringLiteral("INDEX 01 %1").arg("00:00:00"));
             }
             else {
                 // With pregap ..................
                 if (createPreGapFile) {
-                    writeLine(out, QString("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFilePath(mDisc->preGapTrack())).fileName()));
-                    writeLine(out, QString("TRACK %1 AUDIO").arg(i + 1, 2, 10, QChar('0')));
+                    writeLine(out, QStringLiteral("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFilePath(mDisc->preGapTrack())).fileName()));
+                    writeLine(out, QStringLiteral("TRACK %1 AUDIO").arg(i + 1, 2, 10, QChar('0')));
                     writeTags(out, track);
-                    writeLine(out, QString("INDEX 00 %1").arg("00:00:00"));
-                    writeLine(out, QString("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFileName(track)).fileName()));
-                    writeLine(out, QString("INDEX 01 %1").arg("00:00:00"));
+                    writeLine(out, QStringLiteral("INDEX 00 %1").arg("00:00:00"));
+                    writeLine(out, QStringLiteral("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFileName(track)).fileName()));
+                    writeLine(out, QStringLiteral("INDEX 01 %1").arg("00:00:00"));
                 }
                 else {
-                    writeLine(out, QString("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFileName(track)).fileName()));
-                    writeLine(out, QString("TRACK %1 AUDIO").arg(i + 1, 2, 10, QChar('0')));
+                    writeLine(out, QStringLiteral("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFileName(track)).fileName()));
+                    writeLine(out, QStringLiteral("TRACK %1 AUDIO").arg(i + 1, 2, 10, QChar('0')));
                     writeTags(out, track);
-                    writeLine(out, QString("INDEX 00 %1").arg(index0.toString()));
-                    writeLine(out, QString("INDEX 01 %1").arg(index1.toString()));
+                    writeLine(out, QStringLiteral("INDEX 00 %1").arg(index0.toString()));
+                    writeLine(out, QStringLiteral("INDEX 01 %1").arg(index1.toString()));
                 }
             }
         }
         else {
             if (index0.isNull() || index0 == index1) {
                 // No pregap ....................
-                writeLine(out, QString("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFileName(track)).fileName()));
-                writeLine(out, QString("TRACK %1 AUDIO").arg(i + 1, 2, 10, QChar('0')));
+                writeLine(out, QStringLiteral("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFileName(track)).fileName()));
+                writeLine(out, QStringLiteral("TRACK %1 AUDIO").arg(i + 1, 2, 10, QChar('0')));
                 writeTags(out, track);
-                writeLine(out, QString("INDEX 01 %1").arg("00:00:00"));
+                writeLine(out, QStringLiteral("INDEX 01 %1").arg("00:00:00"));
             }
             else {
                 // With pregap ..................
-                writeLine(out, QString("TRACK %1 AUDIO").arg(i + 1, 2, 10, QChar('0')));
+                writeLine(out, QStringLiteral("TRACK %1 AUDIO").arg(i + 1, 2, 10, QChar('0')));
                 writeTags(out, track);
-                writeLine(out, QString("INDEX 00 %1").arg((index0 - prevIndex).toString()));
-                writeLine(out, QString("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFileName(track)).fileName()));
-                writeLine(out, QString("INDEX 01 %1").arg("00:00:00"));
+                writeLine(out, QStringLiteral("INDEX 00 %1").arg((index0 - prevIndex).toString()));
+                writeLine(out, QStringLiteral("FILE \"%1\" WAVE").arg(QFileInfo(mProfile.resultFileName(track)).fileName()));
+                writeLine(out, QStringLiteral("INDEX 01 %1").arg("00:00:00"));
             }
         }
         prevIndex = index1;
@@ -234,7 +234,7 @@ QString CueCreator::writeToFile(const QString &fileTemplate)
     }
 
     if (track->trackNum() > 1) {
-        fileName += QString(".tracks %1-%2").arg(track->trackNum()).arg(mDisc->tracks().last()->trackNum());
+        fileName += QStringLiteral(".tracks %1-%2").arg(track->trackNum()).arg(mDisc->tracks().last()->trackNum());
     }
 
     fileName += ".cue";

--- a/converter/decoder.cpp
+++ b/converter/decoder.cpp
@@ -145,7 +145,7 @@ void Decoder::openProcess()
     mProcess->start(QDir::toNativeSeparators(program->path()), mFormat->decoderArgs(mInputFile));
     bool res = mProcess->waitForStarted();
     if (!res) {
-        throw FlaconError(QString("Can't start '%1': %2")
+        throw FlaconError(QStringLiteral("Can't start '%1': %2")
                                   .arg(program->path(), mProcess->errorString()));
     }
 
@@ -184,7 +184,7 @@ void mustWrite(const char *buf, qint64 maxSize, QIODevice *outDevice)
         outDevice->waitForBytesWritten(10000);
         qint64 n = outDevice->write(buf + done, maxSize - done);
         if (n < 0)
-            throw FlaconError(QString("Can't write %1 bytes. %2")
+            throw FlaconError(QStringLiteral("Can't write %1 bytes. %2")
                                       .arg(maxSize - done)
                                       .arg(outDevice->errorString()));
 
@@ -273,7 +273,7 @@ void Decoder::extract(const CueTime &start, const CueTime &end, QIODevice *outDe
             qint64 n = qMin(qint64(MAX_BUF_SIZE), remains);
             n        = input->read(buf, n);
             if (n < 0)
-                throw FlaconError(QString("Can't read %1 bytes").arg(remains));
+                throw FlaconError(QStringLiteral("Can't read %1 bytes").arg(remains));
 
             remains -= n;
 

--- a/converter/discpipline.cpp
+++ b/converter/discpipline.cpp
@@ -160,7 +160,7 @@ DiscPipeline::DiscPipeline(const Profile &profile, Disc *disc, const QVector<con
 
     createDir(dir);
 
-    mTmpDir = new QTemporaryDir(QString("%1/tmp").arg(dir));
+    mTmpDir = new QTemporaryDir(QStringLiteral("%1/tmp").arg(dir));
     mTmpDir->setAutoRemove(true);
 
     for (const ConvTrack &track : std::as_const(mTracks)) {
@@ -245,7 +245,7 @@ void DiscPipeline::startSplitter(const SplitterRequest &request)
     Splitter *splitter = new Splitter(mDisc, request.tracks, request.outDir);
     splitter->setPregapType(request.pregapType);
     QPointer<WorkerThread> thread = new WorkerThread(splitter, this);
-    thread->setObjectName(QString("%1 splitter").arg(mDisc->cueFilePath()));
+    thread->setObjectName(QStringLiteral("%1 splitter").arg(mDisc->cueFilePath()));
 
     connect(this, &DiscPipeline::stopAllThreads, thread, &Conv::WorkerThread::deleteLater);
     connect(splitter, &Splitter::trackProgress, this, &DiscPipeline::trackProgress);
@@ -301,7 +301,7 @@ void DiscPipeline::startEncoder(const ConvTrack &track, const QString &inputFile
     encoder->setCoverImage(mCoverImage);
 
     QPointer<WorkerThread> thread = new WorkerThread(encoder, this);
-    thread->setObjectName(QString("%1 encoder track %2").arg(track.disc()->cueFilePath()).arg(track.index()));
+    thread->setObjectName(QStringLiteral("%1 encoder track %2").arg(track.disc()->cueFilePath()).arg(track.index()));
 
     connect(this, &DiscPipeline::stopAllThreads, thread, &Conv::WorkerThread::deleteLater);
     connect(encoder, &Encoder::trackProgress, this, &DiscPipeline::trackProgress);
@@ -536,7 +536,7 @@ void DiscPipeline::copyCoverImage() const
     }
 
     QString dir  = QFileInfo(mProfile.resultFilePath(&mTracks.first())).dir().absolutePath();
-    QString dest = QDir(dir).absoluteFilePath(QString("cover.%1").arg(QFileInfo(file).suffix()));
+    QString dest = QDir(dir).absoluteFilePath(QStringLiteral("cover.%1").arg(QFileInfo(file).suffix()));
 
     CoverImage image = CoverImage(file, size);
     image.saveAs(dest);
@@ -556,7 +556,7 @@ void DiscPipeline::createEmbedImage()
 
     mCoverImage = CoverImage(file, size);
 
-    QString tmpCoverFile = QDir(mTmpDir->path()).absoluteFilePath(QString("cover.%1").arg(QFileInfo(file).suffix()));
+    QString tmpCoverFile = QDir(mTmpDir->path()).absoluteFilePath(QStringLiteral("cover.%1").arg(QFileInfo(file).suffix()));
     mCoverImage.saveTmpFile(tmpCoverFile);
 }
 

--- a/converter/encoder.cpp
+++ b/converter/encoder.cpp
@@ -323,7 +323,7 @@ QStringList Encoder::resamplerArgs(int bitsPerSample, int sampleRate, const QStr
 
     args << "-"; // Read from STDIN
     if (bitsPerSample) {
-        args << "-b" << QString("%1").arg(bitsPerSample);
+        args << "-b" << QStringLiteral("%1").arg(bitsPerSample);
     }
 
     args << "--type"
@@ -333,7 +333,7 @@ QStringList Encoder::resamplerArgs(int bitsPerSample, int sampleRate, const QStr
     if (sampleRate) {
         args << "rate";
         args << "-v"; // very high quality
-        args << QString("%1").arg(sampleRate);
+        args << QStringLiteral("%1").arg(sampleRate);
     }
 
     return args;

--- a/converter/extprocess.cpp
+++ b/converter/extprocess.cpp
@@ -41,7 +41,7 @@ ExtProcess::ExtProcess(QObject *parent) :
 void ExtProcess::handleError(QProcess::ProcessError error)
 {
     qCWarning(LOG) << "ERROR";
-    qCWarning(LOG) << QString("%1: The '%2' program crashes").arg(objectName()).arg(program());
+    qCWarning(LOG) << QStringLiteral("%1: The '%2' program crashes").arg(objectName()).arg(program());
     qCWarning(LOG) << "Program with args:" << debugProgramArgs(program(), arguments());
     qCWarning(LOG) << "Error:" << error;
     qCWarning(LOG) << "Error string:" << errorString();
@@ -51,6 +51,6 @@ void ExtProcess::handleError(QProcess::ProcessError error)
         qCWarning(LOG) << "....................";
     }
 
-    QString msg = QString("The '%1' program crashes with an error: %2").arg(program()).arg(errorString());
+    QString msg = QStringLiteral("The '%1' program crashes with an error: %2").arg(program()).arg(errorString());
     throw FlaconError(msg);
 }

--- a/converter/replaygain.cpp
+++ b/converter/replaygain.cpp
@@ -448,7 +448,7 @@ size_t TrackGain::Engine::loadHeader(const char *data, size_t size)
     }
 
     if (!mYuleCoeffA) {
-        throw FlaconError(QString("sample rate of %1 is not supported!").arg(header.sampleRate()));
+        throw FlaconError(QStringLiteral("sample rate of %1 is not supported!").arg(header.sampleRate()));
     }
 
     // clang-format off

--- a/converter/splitter.cpp
+++ b/converter/splitter.cpp
@@ -153,7 +153,7 @@ InputAudioFile Splitter::Job::getInputAudioFile(const QByteArray &fileTag) const
         }
     }
 
-    throw FlaconError(QString("Incorrect file tag %1").arg(fileTag.data()));
+    throw FlaconError(QStringLiteral("Incorrect file tag %1").arg(fileTag.data()));
 }
 
 /************************************************
@@ -181,7 +181,7 @@ void Splitter::setPregapType(const PreGapType &pregapType)
 void Splitter::run()
 {
     static QAtomicInteger<quint32> globalUid(1);
-    QString                        uid = QString("%1").arg(globalUid.fetchAndAddRelaxed(1), 4, 10, QLatin1Char('0'));
+    QString                        uid = QStringLiteral("%1").arg(globalUid.fetchAndAddRelaxed(1), 4, 10, QLatin1Char('0'));
 
     // ******************************************
     // Create jobs
@@ -189,7 +189,7 @@ void Splitter::run()
     for (const ConvTrack &track : mTracks) {
         if (track.isPregap()) {
             Job job(mDisc, mTracks.first(), true, false, false);
-            job.outFileName = QString("%1/pregap-%2.wav").arg(mOutDir, uid);
+            job.outFileName = QStringLiteral("%1/pregap-%2.wav").arg(mOutDir, uid);
             job.isPregap    = true;
             jobs << job;
             continue;
@@ -197,7 +197,7 @@ void Splitter::run()
 
         bool addPregap = (track.index() == 0 && mPregapType == PreGapType::AddToFirstTrack);
         Job  job(mDisc, track, addPregap, true, true);
-        job.outFileName = QString("%1/track-%2_%3.wav").arg(mOutDir, uid).arg(track.trackNum(), 2, 10, QLatin1Char('0'));
+        job.outFileName = QStringLiteral("%1/track-%2_%3.wav").arg(mOutDir, uid).arg(track.trackNum(), 2, 10, QLatin1Char('0'));
         jobs << job;
     }
 

--- a/converter/wavheader.cpp
+++ b/converter/wavheader.cpp
@@ -62,11 +62,11 @@ static inline void mustRead(QIODevice *device, char *data, qint64 size, int msec
 
         qint64 n = device->read(d, left);
         if (n < 0) {
-            throw FlaconError(QString("Error reading data: %1").arg(device->errorString()));
+            throw FlaconError(QStringLiteral("Error reading data: %1").arg(device->errorString()));
         }
         else if (n == 0) {
             if (!device->isSequential()) {
-                throw FlaconError(QString("Unexpected end of file on %1").arg(device->pos()));
+                throw FlaconError(QStringLiteral("Unexpected end of file on %1").arg(device->pos()));
             }
         }
 
@@ -328,7 +328,7 @@ void WavHeader::readWavHeader(QIODevice *stream)
         }
 
         if (chunkSize < 1) {
-            throw FlaconError(QString("[WAV] incorrect chunk size %1 at %2").arg(chunkSize).arg(pos - 4));
+            throw FlaconError(QStringLiteral("[WAV] incorrect chunk size %1 at %2").arg(chunkSize).arg(pos - 4));
         }
 
         if (chunkId == WAV_FMT) {
@@ -382,7 +382,7 @@ void WavHeader::readWave64Header(QIODevice *stream)
         }
 
         if (chunkSize < 1) {
-            throw FlaconError(QString("[WAV] incorrect chunk size %1 at %2").arg(chunkSize).arg(pos - 4));
+            throw FlaconError(QStringLiteral("[WAV] incorrect chunk size %1 at %2").arg(chunkSize).arg(pos - 4));
         }
 
         if (chunkId.startsWidth(WAV_FMT)) {
@@ -476,7 +476,7 @@ void checkFormat(quint16 format)
             return;
     }
 
-    throw FlaconError(QString("unknown format (%1) in WAVE header").arg(format, 0, 16));
+    throw FlaconError(QStringLiteral("unknown format (%1) in WAVE header").arg(format, 0, 16));
 }
 
 /************************************************

--- a/cuedata.cpp
+++ b/cuedata.cpp
@@ -230,7 +230,7 @@ void CueData::parseLine(const QByteArray &line, QByteArray &tag, QByteArray &val
                                       .arg(mFileName)
                                       .arg(lineNum));
 
-        tag   = QString("%1 %2").arg(INDEX_TAG).arg(num, 2, 10, QChar('0')).toLatin1();
+        tag   = QStringLiteral("%1 %2").arg(INDEX_TAG).arg(num, 2, 10, QChar('0')).toLatin1();
         value = rightPart(value, ' ').trimmed();
     }
 }

--- a/extprogram.cpp
+++ b/extprogram.cpp
@@ -145,7 +145,7 @@ QProcess *ExtProgram::open(QObject *parent) const
 
     proc->connect(proc, &QProcess::errorOccurred, proc, [proc](QProcess::ProcessError error) {
         qCWarning(LOG) << "ERROR";
-        qCWarning(LOG) << QString("%1: The '%2' program crashes").arg(proc->objectName()).arg(proc->program());
+        qCWarning(LOG) << QStringLiteral("%1: The '%2' program crashes").arg(proc->objectName()).arg(proc->program());
         qCWarning(LOG) << "Program with args:" << debugProgramArgs(proc->program(), proc->arguments());
         qCWarning(LOG) << "Error:" << error;
         qCWarning(LOG) << "Error string:" << proc->errorString();
@@ -155,7 +155,7 @@ QProcess *ExtProgram::open(QObject *parent) const
             qCWarning(LOG) << "....................";
         }
 
-        QString msg = QString("The '%1' program crashes with an error: %2").arg(proc->program()).arg(proc->errorString());
+        QString msg = QStringLiteral("The '%1' program crashes with an error: %2").arg(proc->program()).arg(proc->errorString());
         throw FlaconError(msg);
     });
 

--- a/formats_in/informat.cpp
+++ b/formats_in/informat.cpp
@@ -81,7 +81,7 @@ const QStringList InputFormat::allFileExts()
 {
     QStringList res;
     foreach (const InputFormat *format, allFormats()) {
-        res << QString("*.%1").arg(format->ext());
+        res << QStringLiteral("*.%1").arg(format->ext());
     }
     return res;
 }

--- a/formats_out/alac/alacoutformat.cpp
+++ b/formats_out/alac/alacoutformat.cpp
@@ -75,7 +75,7 @@ QStringList OutFormat_Alac::encoderArgs(const Profile &profile, const QString &o
 
     // Settings .................................................
     if (profile.encoderValue("Compression").toInt() == 0) {
-        args << QString("--fast");
+        args << QStringLiteral("--fast");
     }
 
     args << "-";

--- a/formats_out/flac/flacoutformat.cpp
+++ b/formats_out/flac/flacoutformat.cpp
@@ -108,7 +108,7 @@ QStringList OutFormat_Flac::encoderArgs(const Profile &profile, const QString &o
 
     // Settings .................................................
     // Compression parametr really looks like --compression-level-N
-    args << QString("--compression-level-%1").arg(profile.encoderValue("Compression").toString());
+    args << QStringLiteral("--compression-level-%1").arg(profile.encoderValue("Compression").toString());
 
     args << "-";
     args << "-o" << outFile;

--- a/formats_out/metadatawriter.cpp
+++ b/formats_out/metadatawriter.cpp
@@ -46,7 +46,7 @@ MetadataWriter::MetadataWriter(const QString &)
  ************************************************/
 QString MetadataWriter::gainToString(float &gain) const
 {
-    return QString("%1 dB").arg(gain, 0, 'f', 2);
+    return QStringLiteral("%1 dB").arg(gain, 0, 'f', 2);
 }
 
 /************************************************
@@ -54,7 +54,7 @@ QString MetadataWriter::gainToString(float &gain) const
  ************************************************/
 QString MetadataWriter::peakToString(float &peak) const
 {
-    return QString("%1").arg(peak, 0, 'f', 6);
+    return QStringLiteral("%1").arg(peak, 0, 'f', 6);
 }
 
 /************************************************
@@ -160,8 +160,8 @@ void MetadataWriter::setApeTags(TagLib::APE::Tag *tags, const Track &track) cons
     writeStrTag("COMMENT", track.comment());
     writeStrTag("DISCID", track.discId());
 
-    writeStrTag("TRACK", QString("%1/%2").arg(track.trackNum()).arg(track.trackCount()));
-    writeStrTag("PART", QString("%1").arg(track.discNum()));
+    writeStrTag("TRACK", QStringLiteral("%1/%2").arg(track.trackNum()).arg(track.trackCount()));
+    writeStrTag("PART", QStringLiteral("%1").arg(track.discNum()));
 }
 
 /************************************************
@@ -172,7 +172,7 @@ void MetadataWriter::setApeCoverImage(TagLib::APE::Tag *tags, const CoverImage &
     TagLib::ByteVector imgData(image.data().data(), image.data().size());
 
     TagLib::ByteVector data;
-    data.append(QString("Cover Art (Front).%1").arg(image.fileExt()).toUtf8().data());
+    data.append(QStringLiteral("Cover Art (Front).%1").arg(image.fileExt()).toUtf8().data());
     data.append(TagLib::ByteVector(1, 0));
     data.append(imgData);
     tags->setItem("Cover Art (Front)", TagLib::APE::Item("Cover Art (Front)", data, true));
@@ -254,8 +254,8 @@ void Mp4MetaDataWriter::setTags(const Track &track)
     writeStrTag("TITLE", track.title());
     writeStrTag("ALBUMARTIST", track.albumArtist());
     writeStrTag("COMMENT", track.comment());
-    writeStrTag("TRACKNUMBER", QString("%1/%2").arg(track.trackNum()).arg(track.trackCount()));
-    writeStrTag("DISCNUMBER", QString("%1/%2").arg(track.discNum()).arg(track.discCount()));
+    writeStrTag("TRACKNUMBER", QStringLiteral("%1/%2").arg(track.trackNum()).arg(track.trackCount()));
+    writeStrTag("DISCNUMBER", QStringLiteral("%1/%2").arg(track.discNum()).arg(track.discCount()));
 
     mFile.setProperties(props);
 }
@@ -286,8 +286,8 @@ void Mp4MetaDataWriter::setCoverImage(const CoverImage &image)
 void Mp4MetaDataWriter::setTrackReplayGain(float gain, float peak)
 {
     TagLib::MP4::Tag *tags = mFile.tag();
-    tags->setItem("----:com.apple.iTunes:replaygain_track_gain", TagLib::StringList(QString("%1 dB").arg(gain, 0, 'f', 2).toStdString()));
-    tags->setItem("----:com.apple.iTunes:replaygain_track_peak", TagLib::StringList(QString("%1").arg(peak, 0, 'f', 6).toStdString()));
+    tags->setItem("----:com.apple.iTunes:replaygain_track_gain", TagLib::StringList(QStringLiteral("%1 dB").arg(gain, 0, 'f', 2).toStdString()));
+    tags->setItem("----:com.apple.iTunes:replaygain_track_peak", TagLib::StringList(QStringLiteral("%1").arg(peak, 0, 'f', 6).toStdString()));
 }
 
 /************************************************
@@ -296,8 +296,8 @@ void Mp4MetaDataWriter::setTrackReplayGain(float gain, float peak)
 void Mp4MetaDataWriter::setAlbumReplayGain(float gain, float peak)
 {
     TagLib::MP4::Tag *tags = mFile.tag();
-    tags->setItem("----:com.apple.iTunes:replaygain_album_gain", TagLib::StringList(QString("%1 dB").arg(gain, 0, 'f', 2).toStdString()));
-    tags->setItem("----:com.apple.iTunes:replaygain_album_peak", TagLib::StringList(QString("%1").arg(peak, 0, 'f', 6).toStdString()));
+    tags->setItem("----:com.apple.iTunes:replaygain_album_gain", TagLib::StringList(QStringLiteral("%1 dB").arg(gain, 0, 'f', 2).toStdString()));
+    tags->setItem("----:com.apple.iTunes:replaygain_album_peak", TagLib::StringList(QStringLiteral("%1").arg(peak, 0, 'f', 6).toStdString()));
 }
 
 /************************************************

--- a/formats_out/mp3/mp3metadatawriter.cpp
+++ b/formats_out/mp3/mp3metadatawriter.cpp
@@ -102,8 +102,8 @@ void Mp3MetaDataWriter::setTags(const Track &track)
         addFrame(tags, "TPE2")->setText(TagLib::String(track.tag(TagId::AlbumArtist).toUtf8().data(), TagLib::String::UTF8));
     }
 
-    addFrame(tags, "TRCK")->setText(QString("%1/%2").arg(track.trackNum()).arg(track.trackCount()).toStdString());
-    addFrame(tags, "TPOS")->setText(QString("%1/%2").arg(track.discNum()).arg(track.discCount()).toStdString());
+    addFrame(tags, "TRCK")->setText(QStringLiteral("%1/%2").arg(track.trackNum()).arg(track.trackCount()).toStdString());
+    addFrame(tags, "TPOS")->setText(QStringLiteral("%1/%2").arg(track.discNum()).arg(track.discCount()).toStdString());
 }
 
 /************************************************

--- a/formats_out/mp3/out_mp3.cpp
+++ b/formats_out/mp3/out_mp3.cpp
@@ -118,7 +118,7 @@ QStringList OutFormat_Mp3::encoderArgs(const Profile &profile, const QString &ou
 
     else if (preset == VBR_QUALITY) {
         int quality = profile.encoderValue("Quality").toInt();
-        args << "-V" << QString("%1").arg(9 - quality);
+        args << "-V" << QStringLiteral("%1").arg(9 - quality);
     }
 
     // ReplayGain ...............................................

--- a/formats_out/ogg/out_ogg.cpp
+++ b/formats_out/ogg/out_ogg.cpp
@@ -186,7 +186,7 @@ void ConfigPage_Ogg::oggQualitySpinChanged(double value)
     double y1      = kbps[x1 + 1];
     double y2      = kbps[x1 + 2];
     int    bitrate = round((y2 - y1) * (value - x1) + y1);
-    oggQualityLabel->setText(QString("(~%1 kbps)").arg(bitrate));
+    oggQualityLabel->setText(QStringLiteral("(~%1 kbps)").arg(bitrate));
 }
 
 /************************************************

--- a/gui/aboutdialog/aboutdialog.cpp
+++ b/gui/aboutdialog/aboutdialog.cpp
@@ -94,7 +94,7 @@ QString AboutDialog::titleText() const
            "<td style='padding:8px 8px;'>"
             +
 #ifdef GIT_BRANCH
-            QString("<div class=name>Flacon</div> developer version."
+            QStringLiteral("<div class=name>Flacon</div> developer version."
                     "<div class=ver>%1 + git %2</b> "
                     "<a href='https://github.com/flacon/flacon/commit/%3'>%3</a></div>")
                     .arg(FLACON_VERSION)
@@ -102,7 +102,7 @@ QString AboutDialog::titleText() const
                     .arg(GIT_COMMIT_HASH)
             +
 #else
-            QString("<div class=name>Flacon</div><div class=ver>Version %1</div>").arg(FLACON_VERSION) +
+            QStringLiteral("<div class=name>Flacon</div><div class=ver>Version %1</div>").arg(FLACON_VERSION) +
 #endif
             "</td></tr></table>";
 }
@@ -276,7 +276,7 @@ QString AboutInfo::asString() const
 #endif
         foreach (QString url, urls) {
             QString text = QString(url).remove("mailto:").remove("http://");
-            result += QString(" <a href='%1'>%2</a>").arg(url, text);
+            result += QStringLiteral(" <a href='%1'>%2</a>").arg(url, text);
         }
 
         if (!item.description.isEmpty())

--- a/gui/controls.cpp
+++ b/gui/controls.cpp
@@ -159,7 +159,7 @@ OutPatternButton::OutPatternButton(QWidget *parent) :
  ************************************************/
 void OutPatternButton::addPattern(const QString &pattern, const QString &title)
 {
-    QAction *act = new QAction(title + QString(" (%1)").arg(pattern), this);
+    QAction *act = new QAction(title + QStringLiteral(" (%1)").arg(pattern), this);
     act->setData(pattern);
     connect(act, &QAction::triggered,
             this, &OutPatternButton::patternTriggered);
@@ -675,7 +675,7 @@ void ProgramEdit::openDialog()
     QString flt = tr("%1 program",
                      "This is part of filter for 'select program' dialog. %1 is a name of required program. Example: 'flac program (flac)'")
                           .arg(mProgram->name())
-            + QString(" (%1);;").arg(mProgram->name()) + tr("All files", "This is part of filter for 'select program' dialog. 'All files (*)'") + " (*)";
+            + QStringLiteral(" (%1);;").arg(mProgram->name()) + tr("All files", "This is part of filter for 'select program' dialog. 'All files (*)'") + " (*)";
 
     QString fileName = !text().isEmpty() ? text() : "/usr/bin/" + mProgram->name();
 
@@ -871,7 +871,7 @@ void ErrorBox::setMessages(const QStringList &messages)
     QString txt;
     foreach (QString s, mMessgaes) {
         s.replace("\n", "<p>");
-        txt += QString("<li>%1</li>").arg(s);
+        txt += QStringLiteral("<li>%1</li>").arg(s);
     }
 
     setText("<ul>" + txt + "</ul>");

--- a/gui/coverdialog/asynclistwidgetitem.cpp
+++ b/gui/coverdialog/asynclistwidgetitem.cpp
@@ -52,7 +52,7 @@ QImage *loadImage(const QString &fileName, const QSize &size)
     painter.drawImage(rect, img);
 
     //....................................
-    QString sizeStr = QString("%1x%2").arg(imgSize.width()).arg(imgSize.height());
+    QString sizeStr = QStringLiteral("%1x%2").arg(imgSize.width()).arg(imgSize.height());
 
     QFont font = painter.font();
     font.setPointSize(font.pointSize() * 0.8);

--- a/gui/icon.cpp
+++ b/gui/icon.cpp
@@ -119,12 +119,12 @@ Icon::Icon(const QString &fileName) :
 {
     const auto sizes = { 16, 22, 24, 32, 48, 64, 128, 256, 512 };
     for (auto size : sizes) {
-        addFile(QString(":icons/light/%1/%2.png")
+        addFile(QStringLiteral(":icons/light/%1/%2.png")
                         .arg(size, 3, 10, QChar('0'))
                         .arg(fileName),
                 QSize(size, size), QIcon::Normal);
 
-        addFile(QString(":icons/light/%1/%2-disabled.png")
+        addFile(QStringLiteral(":icons/light/%1/%2-disabled.png")
                         .arg(size, 3, 10, QChar('0'))
                         .arg(fileName),
                 QSize(size, size), QIcon::Disabled);

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -780,7 +780,7 @@ QString MainWindow::getOpenFileFilter(bool includeAudio, bool includeCue)
 
     if (includeAudio) {
         foreach (const InputFormat *format, InputFormat::allFormats()) {
-            allFlt << QString(" *.%1").arg(format->ext());
+            allFlt << QStringLiteral(" *.%1").arg(format->ext());
             flt << fltPattern.arg(format->name(), format->ext());
         }
     }
@@ -788,7 +788,7 @@ QString MainWindow::getOpenFileFilter(bool includeAudio, bool includeCue)
     flt.sort();
 
     if (includeCue) {
-        allFlt << QString("*.cue");
+        allFlt << QStringLiteral("*.cue");
         flt.insert(0, fltPattern.arg("CUE", "cue"));
     }
 
@@ -1370,7 +1370,7 @@ static QStringList diskMsgsToHtml(int diskNum, const Disk *disk, const QStringLi
     res << "<ul>";
     for (QString msg : msgs) {
         msg = msg.replace("\n", "<br>");
-        res << QString("<li>%1</li>").arg(msg);
+        res << QStringLiteral("<li>%1</li>").arg(msg);
     }
     res << "</ul>";
     res << "</div>";

--- a/gui/preferences/profilespage/profilespage.cpp
+++ b/gui/preferences/profilespage/profilespage.cpp
@@ -217,7 +217,7 @@ void ProfilesPage::addProfile()
         return;
     }
 
-    QString id = QString("%1_%2")
+    QString id = QStringLiteral("%1_%2")
                          .arg(dialog.formaiId())
                          .arg(QDateTime::currentMSecsSinceEpoch());
 

--- a/gui/trackviewdelegate.cpp
+++ b/gui/trackviewdelegate.cpp
@@ -296,7 +296,7 @@ void TrackViewDelegate::paintTrack(QPainter *painter, const QStyleOptionViewItem
         opt.minimum  = 0;
         opt.maximum  = 100;
         opt.progress = progress;
-        opt.text     = QString("%1 %2%").arg(txt).arg(opt.progress);
+        opt.text     = QStringLiteral("%1 %2%").arg(txt).arg(opt.progress);
 
         QApplication::style()->drawControl(QStyle::CE_ProgressBarContents, &opt, painter);
         QApplication::style()->drawControl(QStyle::CE_ProgressBarLabel, &opt, painter);
@@ -467,7 +467,7 @@ QRect TrackViewDelegate::drawTitle(QPainter *painter, const QRect &windowRect, c
 
     QString text;
     if (!album.isEmpty() || !artist.isEmpty()) {
-        text = QString("%1 / %2").arg(artist, album);
+        text = QStringLiteral("%1 / %2").arg(artist, album);
     }
 
     QRect res;
@@ -709,14 +709,14 @@ bool TrackViewDelegate::helpEvent(QHelpEvent *event, QAbstractItemView *view, co
             html += tr("<b>The conversion is not possible.</b>");
             html += "<ul>";
             for (const QString &s : errs) {
-                html += QString("<li><nobr>%1</nobr></li>").arg(s);
+                html += QStringLiteral("<li><nobr>%1</nobr></li>").arg(s);
             }
             html += "</ul>";
         }
         else {
             html += "<ul>";
             for (const QString &s : warns) {
-                html += QString("<li><nobr>%1</nobr></li>").arg(s);
+                html += QStringLiteral("<li><nobr>%1</nobr></li>").arg(s);
             }
             html += "</ul>";
         }

--- a/gui/trackviewmodel.cpp
+++ b/gui/trackviewmodel.cpp
@@ -312,7 +312,7 @@ QVariant TrackViewModel::trackData(const Track *track, const QModelIndex &index,
     if (role == Qt::DisplayRole || role == Qt::EditRole) {
         switch (index.column()) {
             case TrackView::ColumnTracknum:
-                return QVariant(QString("%1").arg(track->trackNum(), 2, 10, QChar('0')));
+                return QVariant(QStringLiteral("%1").arg(track->trackNum(), 2, 10, QChar('0')));
 
             case TrackView::ColumnDuration:
                 return QVariant(trackDurationToString(track->duration()) + " ");

--- a/internet/dataprovider.cpp
+++ b/internet/dataprovider.cpp
@@ -155,7 +155,7 @@ void InterntService::stop()
 QNetworkReply *InterntService::get(const QNetworkRequest &request)
 {
     QNetworkRequest req = request;
-    req.setRawHeader("User-Agent", QString("Flacon/%1 (https://github.com/flacon/flacon)").arg(FLACON_VERSION).toUtf8());
+    req.setRawHeader("User-Agent", QStringLiteral("Flacon/%1 (https://github.com/flacon/flacon)").arg(FLACON_VERSION).toUtf8());
     qCDebug(LOG).noquote() << req.url().toEncoded();
 
     QNetworkReply *reply = networkAccessManager()->get(req);

--- a/internet/discogs.cpp
+++ b/internet/discogs.cpp
@@ -81,13 +81,13 @@ void Discogs::start()
     mRequestAlbum      = track->album();
 
     QStringList query;
-    query << QString("artist=\"%1\"").arg(mRequestArtist.toHtmlEscaped());
-    query << QString("release_title=\"%1\"").arg(mRequestAlbum.toHtmlEscaped());
+    query << QStringLiteral("artist=\"%1\"").arg(mRequestArtist.toHtmlEscaped());
+    query << QStringLiteral("release_title=\"%1\"").arg(mRequestAlbum.toHtmlEscaped());
 
     QUrl url = QString(SEARCH_URL).arg(query.join("&"));
 
     QNetworkRequest request(url);
-    request.setRawHeader("Authorization", QString("Discogs token=%1").arg(TOKEN).toUtf8().data());
+    request.setRawHeader("Authorization", QStringLiteral("Discogs token=%1").arg(TOKEN).toUtf8().data());
 
     QNetworkReply *reply = get(request);
     connect(reply, &QNetworkReply::finished, this, [this, reply]() { searchReady(reply); });
@@ -201,12 +201,12 @@ void Discogs::processResults()
     int n = 0;
     for (Tracks &t : mResult) {
         n++;
-        t.setUri(QString("https://discogs.com/Artist=%1&Album=%2&num=%3").arg(mRequestArtist, mRequestAlbum).arg(n));
+        t.setUri(QStringLiteral("https://discogs.com/Artist=%1&Album=%2&num=%3").arg(mRequestArtist, mRequestAlbum).arg(n));
         if (mResult.size() == 1) {
-            t.setTitle(QString("%1 / %2   [ Discogs ]").arg(mRequestArtist, mRequestAlbum));
+            t.setTitle(QStringLiteral("%1 / %2   [ Discogs ]").arg(mRequestArtist, mRequestAlbum));
         }
         else {
-            t.setTitle(QString("%1 / %2   [ Discogs %3 ]").arg(mRequestArtist, mRequestAlbum).arg(n));
+            t.setTitle(QStringLiteral("%1 / %2   [ Discogs %3 ]").arg(mRequestArtist, mRequestAlbum).arg(n));
         }
     }
 

--- a/internet/musicbrainz.cpp
+++ b/internet/musicbrainz.cpp
@@ -94,8 +94,8 @@ void MusicBrainz::start()
     mRequestAlbum      = track->album();
 
     QStringList query;
-    query << QString("artist:\"%1\"").arg(mRequestArtist.toHtmlEscaped());
-    query << QString("release:\"%1\"").arg(mRequestAlbum.toHtmlEscaped());
+    query << QStringLiteral("artist:\"%1\"").arg(mRequestArtist.toHtmlEscaped());
+    query << QStringLiteral("release:\"%1\"").arg(mRequestAlbum.toHtmlEscaped());
 
     QUrl url = QString(SEARCH_URL).arg(query.join("%20AND%20"));
 
@@ -298,12 +298,12 @@ void MusicBrainz::processResults()
     int n = 0;
     for (Tracks &t : mResult) {
         n++;
-        t.setUri(QString("https://musicbrainz.org/artis=%1&album=%2&num=%3").arg(mRequestArtist, mRequestAlbum).arg(n));
+        t.setUri(QStringLiteral("https://musicbrainz.org/artis=%1&album=%2&num=%3").arg(mRequestArtist, mRequestAlbum).arg(n));
         if (mResult.size() == 1) {
-            t.setTitle(QString("%1 / %2   [ MusicBrainz ]").arg(mRequestArtist, mRequestAlbum));
+            t.setTitle(QStringLiteral("%1 / %2   [ MusicBrainz ]").arg(mRequestArtist, mRequestAlbum));
         }
         else {
-            t.setTitle(QString("%1 / %2   [ MusicBrainz %3 ]").arg(mRequestArtist, mRequestAlbum).arg(n));
+            t.setTitle(QStringLiteral("%1 / %2   [ MusicBrainz %3 ]").arg(mRequestArtist, mRequestAlbum).arg(n));
         }
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -157,7 +157,7 @@ void translate(QApplication *app)
     }
 
     QTranslator *appTranslator = new QTranslator(app);
-    if (appTranslator->load(QString("flacon_%2.qm").arg(locale)) || appTranslator->load(QString("%1/flacon_%2.qm").arg(appDir, locale))) {
+    if (appTranslator->load(QStringLiteral("flacon_%2.qm").arg(locale)) || appTranslator->load(QStringLiteral("%1/flacon_%2.qm").arg(appDir, locale))) {
         app->installTranslator(appTranslator);
     }
 }

--- a/patternexpander.cpp
+++ b/patternexpander.cpp
@@ -128,7 +128,7 @@ static QString doExpandPattern(const QString &pattern, const Tokens &tokens, boo
                     if (c == '%')
                         res += "%";
                     else
-                        res += QString("%") + c;
+                        res += QStringLiteral("%") + c;
                 }
             }
             else {
@@ -162,10 +162,10 @@ static QString doExpandPattern(const QString &pattern, const Tokens &tokens, boo
 QString PatternExpander::expand(const QString &pattern) const
 {
     Tokens tokens;
-    tokens.insert(QChar('N'), QString("%1").arg(mTrackCount, 2, 10, QChar('0')));
-    tokens.insert(QChar('n'), QString("%1").arg(mTrackNum, 2, 10, QChar('0')));
-    tokens.insert(QChar('D'), QString("%1").arg(mDiscCount, 2, 10, QChar('0')));
-    tokens.insert(QChar('d'), QString("%1").arg(mDiscNum, 2, 10, QChar('0')));
+    tokens.insert(QChar('N'), QStringLiteral("%1").arg(mTrackCount, 2, 10, QChar('0')));
+    tokens.insert(QChar('n'), QStringLiteral("%1").arg(mTrackNum, 2, 10, QChar('0')));
+    tokens.insert(QChar('D'), QStringLiteral("%1").arg(mDiscCount, 2, 10, QChar('0')));
+    tokens.insert(QChar('d'), QStringLiteral("%1").arg(mDiscNum, 2, 10, QChar('0')));
     tokens.insert(QChar('A'), safeString(mAlbum));
     tokens.insert(QChar('t'), safeString(mTrackTitle));
     tokens.insert(QChar('a'), safeString(mArtist));
@@ -229,7 +229,7 @@ QString PatternExpander::resultFileName(const QString &aPattern, const Track *tr
 {
     QString pattern = aPattern;
     if (pattern.isEmpty()) {
-        pattern = QString("%a/%y - %A/%n - %t");
+        pattern = QStringLiteral("%a/%y - %A/%n - %t");
     }
 
     int n = lastDirSeparattor(pattern);

--- a/scanner.cpp
+++ b/scanner.cpp
@@ -55,7 +55,7 @@ void Scanner::start(const QString &startDir)
 
     QStringList exts;
     foreach (const InputFormat *format, InputFormat::allFormats()) {
-        exts << QString("*.%1").arg(format->ext());
+        exts << QStringLiteral("*.%1").arg(format->ext());
     }
 
     QQueue<QString> query;

--- a/settings.cpp
+++ b/settings.cpp
@@ -108,7 +108,7 @@ Settings::Settings(const QString &fileName) :
  ************************************************/
 Profile Settings::readProfile(const QString &profileId)
 {
-    QString group = QString("%1/%2").arg(PROFILES_GROUP, profileId);
+    QString group = QStringLiteral("%1/%2").arg(PROFILES_GROUP, profileId);
 
     beginGroup(group);
 
@@ -169,7 +169,7 @@ void Settings::writeProfile(const Profile &profile)
         return;
     }
 
-    QString group = QString("%1/%2").arg(PROFILES_GROUP, profile.id());
+    QString group = QStringLiteral("%1/%2").arg(PROFILES_GROUP, profile.id());
     beginGroup(group);
 
     setValue(PROFILE_NAME_KEY, profile.name());
@@ -341,7 +341,7 @@ void Settings::writeCurrentProfileId(const QString &profileId)
 void Settings::readExtPrograms() const
 {
     for (ExtProgram *p : ExtProgram::allPrograms()) {
-        auto key = QString("%1/%2").arg(PROGRAMS_GROUP, p->name());
+        auto key = QStringLiteral("%1/%2").arg(PROGRAMS_GROUP, p->name());
 
         QString path = value(key).toString();
         if (path.isEmpty()) {
@@ -358,7 +358,7 @@ void Settings::writeExtPrograms()
 {
     remove(PROGRAMS_GROUP);
     for (ExtProgram *p : ExtProgram::allPrograms()) {
-        auto key = QString("%1/%2").arg(PROGRAMS_GROUP, p->name());
+        auto key = QStringLiteral("%1/%2").arg(PROGRAMS_GROUP, p->name());
         setValue(key, p->path());
     }
 }

--- a/tests/convertertest.cpp
+++ b/tests/convertertest.cpp
@@ -40,11 +40,11 @@ static QString findFile(const QString &dir, const QString &pattern)
     QStringList files = QDir(dir).entryList(QStringList(pattern), QDir::Filter::Files);
 
     if (files.isEmpty()) {
-        throw FlaconError(QString("File %1 not found").arg(pattern));
+        throw FlaconError(QStringLiteral("File %1 not found").arg(pattern));
     }
 
     if (files.count() > 1) {
-        throw FlaconError(QString("Mask %1 matches multiple files.").arg(pattern));
+        throw FlaconError(QStringLiteral("Mask %1 matches multiple files.").arg(pattern));
     }
 
     return files.first();
@@ -98,7 +98,7 @@ ConverterTest::ConverterTest(const QString &dataDir, const QString &dir, const Q
             ;
 
             if (!QFile::copy(src, dest))
-                QFAIL(QString("Can't copy audio file \"%1\"").arg(src).toLocal8Bit());
+                QFAIL(QStringLiteral("Can't copy audio file \"%1\"").arg(src).toLocal8Bit());
         }
 
         // Generate file ........................
@@ -123,7 +123,7 @@ ConverterTest::ConverterTest(const QString &dataDir, const QString &dir, const Q
 
         QFileInfo(dest).dir().mkpath(".");
         if (!QFile::copy(src, dest))
-            QFAIL(QString("Can't copy CUE file \"%1\"").arg(src).toLocal8Bit());
+            QFAIL(QStringLiteral("Can't copy CUE file \"%1\"").arg(src).toLocal8Bit());
     }
     spec.endGroup();
     // ..........................................
@@ -136,7 +136,7 @@ ConverterTest::ConverterTest(const QString &dataDir, const QString &dir, const Q
 
         QFileInfo(dest).dir().mkpath(".");
         if (!QFile::copy(src, dest)) {
-            QFAIL(QString("Can't copy file \"%1\"").arg(src).toLocal8Bit());
+            QFAIL(QStringLiteral("Can't copy file \"%1\"").arg(src).toLocal8Bit());
         }
     }
     spec.endGroup();
@@ -149,7 +149,7 @@ ConverterTest::ConverterTest(const QString &dataDir, const QString &dir, const Q
         QString src  = dataDir + "/" + spec.value(key).toString();
         QFileInfo(dest).dir().mkpath(".");
         if (!QFile::copy(src, dest))
-            QFAIL(QString("Can't copy CUE file \"%1\"").arg(src).toLocal8Bit());
+            QFAIL(QStringLiteral("Can't copy CUE file \"%1\"").arg(src).toLocal8Bit());
     }
     spec.endGroup();
     // ..........................................
@@ -212,7 +212,7 @@ void ConverterTest::srcAudioExec(QSettings &spec) const
         QString     prog = args.takeFirst();
 
         if (QProcess::execute(prog, args) != 0) {
-            throw FlaconError(QString("Command `%1` failed!").arg(cmd));
+            throw FlaconError(QStringLiteral("Command `%1` failed!").arg(cmd));
         }
     }
 
@@ -287,14 +287,14 @@ bool ConverterTest::run()
     proc.start(flacon, args);
 
     if (!proc.waitForFinished(30 * 1000)) {
-        FAIL(QString("The program timed out waiting for the result: %1.")
+        FAIL(QStringLiteral("The program timed out waiting for the result: %1.")
                      .arg(QString::fromLocal8Bit(proc.readAllStandardError()))
                      .toLocal8Bit());
         return false;
     }
 
     if (proc.exitCode() != 0) {
-        FAIL(QString("flacon returned non-zero exit status %1: %2")
+        FAIL(QStringLiteral("flacon returned non-zero exit status %1: %2")
                      .arg(proc.exitCode())
                      .arg(QString::fromLocal8Bit(proc.readAll()))
                      .toLocal8Bit());
@@ -382,7 +382,7 @@ void ConverterTest::check()
     //        QString cmd = spec.value(key).toString();
     //        int     res = QProcess::execute(cmd);
     //        if (res != 0) {
-    //            QFAIL(QString("Chack is failed for %1").arg(cmd).toLocal8Bit());
+    //            QFAIL(QStringLiteral("Chack is failed for %1").arg(cmd).toLocal8Bit());
     //        }
     //    }
     //    spec.endGroup();
@@ -390,17 +390,17 @@ void ConverterTest::check()
     //    // ******************************************
 
     if (!missing.isEmpty())
-        msg += QString("\nFiles not exists in %1:\n  * %2")
+        msg += QStringLiteral("\nFiles not exists in %1:\n  * %2")
                        .arg(mOutDir)
                        .arg(missing.join("\n  * "));
 
     if (!files.isEmpty())
-        msg += QString("\nFiles exists in %1:\n  * %2")
+        msg += QStringLiteral("\nFiles exists in %1:\n  * %2")
                        .arg(mOutDir)
                        .arg(files.join("\n  * "));
 
     if (!msg.isEmpty())
-        QFAIL(QString("%1\n%2").arg(QTest::currentDataTag()).arg(msg).toLocal8Bit().data());
+        QFAIL(QStringLiteral("%1\n%2").arg(QTest::currentDataTag()).arg(msg).toLocal8Bit().data());
 
     // ******************************************
     // Check tags
@@ -486,7 +486,7 @@ bool ConverterTest::checkReplayGain()
                     double d = s.toDouble(&ok);
 
                     if (!ok) {
-                        qWarning() << QString("Can't convert actual value \"%1\" to double (tag: %2)").arg(actual.toString(), tag).toLocal8Bit();
+                        qWarning() << QStringLiteral("Can't convert actual value \"%1\" to double (tag: %2)").arg(actual.toString(), tag).toLocal8Bit();
                         errors = true;
                         continue;
                     }
@@ -525,7 +525,7 @@ QStringList ConverterTest::readFile(const QString &fileName)
     file.open(QIODevice::ReadOnly);
 
     if (!file.isOpen()) {
-        FAIL(QString("Can't open file %1: %2").arg(file.fileName(), file.errorString()).toLocal8Bit().data());
+        FAIL(QStringLiteral("Can't open file %1: %2").arg(file.fileName(), file.errorString()).toLocal8Bit().data());
         return res;
     }
 
@@ -548,7 +548,7 @@ void ConverterTest::writeFile(const QStringList &strings, const QString &fileNam
     file.open(QIODevice::WriteOnly);
 
     if (!file.isOpen())
-        QFAIL(QString("Can't open file %1: %2").arg(file.fileName(), file.errorString()).toLocal8Bit().data());
+        QFAIL(QStringLiteral("Can't open file %1: %2").arg(file.fileName(), file.errorString()).toLocal8Bit().data());
 
     foreach (const QString &string, strings) {
         file.write(string.toLocal8Bit());
@@ -605,9 +605,9 @@ void ConverterTest::printFile(const QString &fileName, bool printHeader)
 {
     QTextStream out(stderr);
     if (printHeader) {
-        out << QString("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+        out << QStringLiteral("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
         out << fileName << "\n";
-        out << QString("───────────────────────────────────────────────────────────────────────\n");
+        out << QStringLiteral("───────────────────────────────────────────────────────────────────────\n");
     }
     QFile f(fileName);
     f.open(QFile::ReadOnly);
@@ -615,7 +615,7 @@ void ConverterTest::printFile(const QString &fileName, bool printHeader)
     out << "\n";
 
     if (printHeader) {
-        out << QString("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+        out << QStringLiteral("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
     }
 }
 
@@ -626,7 +626,7 @@ Mediainfo::Mediainfo(const QString &fileName) :
     mFileName(fileName)
 {
     if (!QFileInfo::exists(fileName)) {
-        throw FlaconError(QString("Can't read mediainfo to file '%1' (file don't exists').").arg(mFileName));
+        throw FlaconError(QStringLiteral("Can't read mediainfo to file '%1' (file don't exists').").arg(mFileName));
     }
 
     QStringList args;
@@ -640,7 +640,7 @@ Mediainfo::Mediainfo(const QString &fileName) :
     proc.waitForFinished();
     if (proc.exitCode() != 0) {
         QString err = QString::fromLocal8Bit(proc.readAll());
-        FAIL(QString("Can't read tags from \"%1\": %2").arg(mFileName).arg(err).toLocal8Bit());
+        FAIL(QStringLiteral("Can't read tags from \"%1\": %2").arg(mFileName).arg(err).toLocal8Bit());
     }
 
     QByteArray data = proc.readAllStandardOutput();

--- a/tests/discspec.cpp
+++ b/tests/discspec.cpp
@@ -66,7 +66,7 @@ QString DiscSpec::trackAudioFilePath(int index) const
 
 QString DiscSpec::trackKey(int track, const QString tag) const
 {
-    return QString("TRACKS/%1/%2").arg(track, 2, 10, QChar('0')).arg(tag);
+    return QStringLiteral("TRACKS/%1/%2").arg(track, 2, 10, QChar('0')).arg(tag);
 }
 
 QString DiscSpec::trackValue(int track, const QString &key) const
@@ -180,7 +180,7 @@ void DiscSpec::verifyTrack(const Track *track, const QString &key) const
         return;
     }
 
-    QFAIL(QString("Unknown expected key: %1").arg(key).toLocal8Bit());
+    QFAIL(QStringLiteral("Unknown expected key: %1").arg(key).toLocal8Bit());
 }
 
 void DiscSpec::verify(const Disc &disc) const

--- a/tests/flacontest.cpp
+++ b/tests/flacontest.cpp
@@ -140,7 +140,7 @@ void TestFlacon::checkFileExists(const QString &fileName)
 {
     QFileInfo fi(fileName);
     if (!fi.exists())
-        QFAIL(QString("File not exists:\n\t%1").arg(fi.absoluteFilePath()).toLocal8Bit());
+        QFAIL(QStringLiteral("File not exists:\n\t%1").arg(fi.absoluteFilePath()).toLocal8Bit());
 }
 
 /************************************************
@@ -150,7 +150,7 @@ void TestFlacon::checkFileNotExists(const QString &fileName)
 {
     QFileInfo fi(fileName);
     if (fi.exists())
-        QFAIL(QString("File exists:\n\t%1").arg(fi.absoluteFilePath()).toLocal8Bit());
+        QFAIL(QStringLiteral("File exists:\n\t%1").arg(fi.absoluteFilePath()).toLocal8Bit());
 }
 
 /************************************************
@@ -301,7 +301,7 @@ void TestFlacon::testSafeString_data()
 
     for (char c = 1; c <= 31; ++c) {
         if (c != '\t' && c != '\n')
-            QTest::newRow(QString("01 - \\%1").arg(int(c), 2, 16, QChar('0')).toLocal8Bit())
+            QTest::newRow(QStringLiteral("01 - \\%1").arg(int(c), 2, 16, QChar('0')).toLocal8Bit())
                     << QString(c)
                     << "";
     }
@@ -329,7 +329,7 @@ void TestFlacon::testSafeString_data()
 
     for (char c = 1; c <= 31; ++c) {
         if (c != '\t' && c != '\n')
-            QTest::newRow(QString("02 - A\\%1B").arg(int(c), 2, 16, QChar('0')).toLocal8Bit())
+            QTest::newRow(QStringLiteral("02 - A\\%1B").arg(int(c), 2, 16, QChar('0')).toLocal8Bit())
                     << "A" + QString(c) + "B"
                     << "AB";
     }
@@ -386,7 +386,7 @@ QStringList TestFlacon::readFile(const QString &fileName)
     file.open(QIODevice::ReadOnly);
 
     if (!file.isOpen()) {
-        FAIL(QString("Can't open file %1: %2").arg(file.fileName(), file.errorString()).toLocal8Bit().data());
+        FAIL(QStringLiteral("Can't open file %1: %2").arg(file.fileName(), file.errorString()).toLocal8Bit().data());
         return res;
     }
 
@@ -409,7 +409,7 @@ void TestFlacon::writeFile(const QStringList &strings, const QString &fileName)
     file.open(QIODevice::WriteOnly);
 
     if (!file.isOpen())
-        QFAIL(QString("Can't open file %1: %2").arg(file.fileName(), file.errorString()).toLocal8Bit().data());
+        QFAIL(QStringLiteral("Can't open file %1: %2").arg(file.fileName(), file.errorString()).toLocal8Bit().data());
 
     foreach (const QString &string, strings) {
         file.write(string.toLocal8Bit());
@@ -429,7 +429,7 @@ QString TestFlacon::stigListToString(const QStringList &strings, const QString d
  ************************************************/
 QStringList &operator<<(QStringList &list, int value)
 {
-    return list << QString("%1").arg(value);
+    return list << QStringLiteral("%1").arg(value);
 }
 
 /************************************************
@@ -455,7 +455,7 @@ void TestFlacon::testTrackResultFileName()
     // QCOMPARE(result, expected);
 
     if (result != expected) {
-        QString msg = QString("Compared values are not the same\n   Pattern   %1\n   Actual:   %2\n   Expected: %3").arg(pattern, result, expected);
+        QString msg = QStringLiteral("Compared values are not the same\n   Pattern   %1\n   Actual:   %2\n   Expected: %3").arg(pattern, result, expected);
         QFAIL(msg.toLocal8Bit());
     }
     disc->deleteLater();
@@ -1179,7 +1179,7 @@ void TestFlacon::testTrackResultFilePath()
 
     QString result = profile.resultFilePath(disc->track(0));
     if (QFileInfo(result).absoluteFilePath() != QFileInfo(expected).absoluteFilePath()) {
-        QString msg = QString("Compared values are not the same\n   Actual:   %1 [%2]\n   Expected: %3\n   CueFile: %4").arg(QFileInfo(result).absoluteFilePath(), result, expected, cueFile);
+        QString msg = QStringLiteral("Compared values are not the same\n   Actual:   %1 [%2]\n   Expected: %3\n   CueFile: %4").arg(QFileInfo(result).absoluteFilePath(), result, expected, cueFile);
         QFAIL(msg.toLocal8Bit());
     }
     // QCOMPARE(result, expected);
@@ -1260,7 +1260,7 @@ void TestFlacon::testTrackSetCodepages()
         QFile(testCueFile).remove();
 
     if (!QFile::copy(testDataDir + cueFile, testCueFile))
-        QFAIL(QString("Can't copy file %1 to %2").arg(testDataDir + cueFile, testCueFile).toLocal8Bit().data());
+        QFAIL(QStringLiteral("Can't copy file %1 to %2").arg(testDataDir + cueFile, testCueFile).toLocal8Bit().data());
 
     if (!codepageBefore.isEmpty())
         Settings::i()->setDefaultCodepage(codepageBefore);
@@ -1306,7 +1306,7 @@ void TestFlacon::testTrackSetCodepages()
 
     if (result.join("") != expected.join("")) {
         QString msg = "The result is different from the expected. Use the following command for details:";
-        QString cmd = QString("diff %1 %2").arg(expectedFile, resultFile);
+        QString cmd = QStringLiteral("diff %1 %2").arg(expectedFile, resultFile);
         QFAIL((msg + "\n    " + cmd).toLocal8Bit());
     }
 

--- a/tests/inittestcase.cpp
+++ b/tests/inittestcase.cpp
@@ -57,7 +57,7 @@ static void createWavFile(const QString &fileName, const int duration)
 {
     QFile hdr(TEST_DATA_DIR "CD.wav.hdr");
     if (!hdr.open(QFile::ReadOnly))
-        QTest::qFail(QString("Can't open header file '%1': %2").arg(hdr.fileName()).arg(hdr.errorString()).toLocal8Bit(), __FILE__, __LINE__);
+        QTest::qFail(QStringLiteral("Can't open header file '%1': %2").arg(hdr.fileName()).arg(hdr.errorString()).toLocal8Bit(), __FILE__, __LINE__);
 
     createWavFile(fileName, hdr.readAll(), duration);
 }
@@ -81,12 +81,12 @@ void TestFlacon::initTestCase()
 
     for (auto &p : PROGS) {
         if (p->path().isEmpty()) {
-            QFAIL(QString("%1 program not found").arg(p->name()).toLocal8Bit());
+            QFAIL(QStringLiteral("%1 program not found").arg(p->name()).toLocal8Bit());
         }
     }
 
     if (!QDir().mkpath(mTmpDir))
-        QTest::qFail(QString("Can't create directory '%1'").arg(mTmpDir).toLocal8Bit(), __FILE__, __LINE__);
+        QTest::qFail(QStringLiteral("Can't create directory '%1'").arg(mTmpDir).toLocal8Bit(), __FILE__, __LINE__);
 
     createWavFile(mTmpDir + "1sec.wav", 1);
     createWavFile(mTmpDir + "1min.wav", 60);
@@ -113,7 +113,7 @@ void TestFlacon::initTestCase()
     {
         QFile hdr(TEST_DATA_DIR "24x96.wav.hdr");
         if (!hdr.open(QFile::ReadOnly))
-            QTest::qFail(QString("Can't open header file '%1': %2").arg(hdr.fileName()).arg(hdr.errorString()).toLocal8Bit(), __FILE__, __LINE__);
+            QTest::qFail(QStringLiteral("Can't open header file '%1': %2").arg(hdr.fileName()).arg(hdr.errorString()).toLocal8Bit(), __FILE__, __LINE__);
 
         createWavFile(mAudio_24x96_wav, hdr.readAll(), 900);
     }
@@ -164,7 +164,7 @@ QString TestFlacon::dir(const QString &subTest)
     QString test    = QString::fromLocal8Bit(QTest::currentTestFunction());
     QString subtest = subTest.isEmpty() ? QString::fromLocal8Bit(QTest::currentDataTag()) : subTest;
 
-    return QDir::cleanPath(QString("%1/%2/%3")
+    return QDir::cleanPath(QStringLiteral("%1/%2/%3")
                                    .arg(TEST_OUT_DIR)
                                    .arg(safePath(test))
                                    .arg(safePath(subtest)));
@@ -178,7 +178,7 @@ QString TestFlacon::sourceDir(const QString &subTest)
     QString test    = QString::fromLocal8Bit(QTest::currentTestFunction());
     QString subtest = subTest.isEmpty() ? QString::fromLocal8Bit(QTest::currentDataTag()) : subTest;
 
-    return QDir::cleanPath(QString("%1/%2/%3")
+    return QDir::cleanPath(QStringLiteral("%1/%2/%3")
                                    .arg(mDataDir)
                                    .arg(safePath(test))
                                    .arg(safePath(subtest)));
@@ -199,7 +199,7 @@ void TestFlacon::init()
 
     QDir(dir).removeRecursively();
     if (!QDir().mkpath(dir)) {
-        QTest::qFail(QString("Can't create directory '%1'").arg(dir).toLocal8Bit(), __FILE__, __LINE__);
+        QTest::qFail(QStringLiteral("Can't create directory '%1'").arg(dir).toLocal8Bit(), __FILE__, __LINE__);
     }
 
     Settings::setFileName(dir + "/flacon.conf");

--- a/tests/test_cue.cpp
+++ b/tests/test_cue.cpp
@@ -45,7 +45,7 @@ QFile &operator<<(QFile &file, const QString &value)
  ************************************************/
 QFile &operator<<(QFile &file, const int &value)
 {
-    return file << QString("%1").arg(value);
+    return file << QStringLiteral("%1").arg(value);
 }
 
 /************************************************
@@ -59,7 +59,7 @@ static void write(const Cue &cue, const QString &fileName)
     int t = -1;
     for (const TrackTags &track : cue.tracks()) {
         t++;
-        f << QString("[DISC 01 / TRACK %2]\n").arg(t + 1, 2, 10, QChar('0'));
+        f << QStringLiteral("[DISC 01 / TRACK %2]\n").arg(t + 1, 2, 10, QChar('0'));
 
         f << "\t"
           << "FILE        = " << track.tag(TagId::File) << "\n";
@@ -110,7 +110,7 @@ static void compare(const QString &resFile, const QString &expectedFile)
         if (result.value(key).toString() == expected.value(key).toString())
             continue;
 
-        QString msg = QString("Compared values are not the same\n\tKey\t%1\n\tActual\t%2\n\tExpected\t%3")
+        QString msg = QStringLiteral("Compared values are not the same\n\tKey\t%1\n\tActual\t%2\n\tExpected\t%3")
                               .arg(key)
                               .arg(result.value(key).toString())
                               .arg(expected.value(key).toString());

--- a/tests/test_cuedata.cpp
+++ b/tests/test_cuedata.cpp
@@ -33,7 +33,7 @@ static QString toString(const CueData::Tags &tags)
 {
     QString res;
     for (QByteArray k : tags.keys()) {
-        res += QString("%1 = %2\n").arg(QString::fromLatin1(k)).arg(QString::fromLocal8Bit(tags.value(k)));
+        res += QStringLiteral("%1 = %2\n").arg(QString::fromLatin1(k)).arg(QString::fromLocal8Bit(tags.value(k)));
     }
     return res;
 }
@@ -42,7 +42,7 @@ static QString toString(QSettings &settings)
 {
     QString res;
     for (const QString &k : settings.allKeys()) {
-        res += QString("%1 = %2\n").arg(k).arg(settings.value(k).toString());
+        res += QStringLiteral("%1 = %2\n").arg(k).arg(settings.value(k).toString());
     }
     return res;
 }
@@ -69,7 +69,7 @@ void TestFlacon::testCueData()
         int n = 0;
         for (auto track : result.tracks()) {
             n++;
-            expected.beginGroup(QString("TRACK %1").arg(n, 2, 10, QChar('0')));
+            expected.beginGroup(QStringLiteral("TRACK %1").arg(n, 2, 10, QChar('0')));
             QCOMPARE(toString(track), toString(expected));
             expected.endGroup();
         }

--- a/tests/test_decoder.cpp
+++ b/tests/test_decoder.cpp
@@ -58,7 +58,7 @@ void TestFlacon::testDecoder()
         decoder.open(inputFile);
     }
     catch (FlaconError &err) {
-        QFAIL(QString("Can't open input file '%1': %2").arg(inputFile, err.what()).toLocal8Bit());
+        QFAIL(QStringLiteral("Can't open input file '%1': %2").arg(inputFile, err.what()).toLocal8Bit());
     }
 
     if (!decoder.audioFormat())
@@ -67,13 +67,13 @@ void TestFlacon::testDecoder()
     for (int i = 0; i < tracks.count(); ++i) {
         TestTrack track = tracks.at(i);
 
-        QString flaconFile = QString("%1/%2-flacon.wav").arg(dir()).arg(i + 1, 3, 10, QChar('0'));
+        QString flaconFile = QStringLiteral("%1/%2-flacon.wav").arg(dir()).arg(i + 1, 3, 10, QChar('0'));
 
         try {
             decoder.extract(CueTime(track.start), CueTime(track.end), flaconFile);
         }
         catch (FlaconError &err) {
-            QFAIL(QString("Can't extract file '%1' [%2-%3]: %4")
+            QFAIL(QStringLiteral("Can't extract file '%1' [%2-%3]: %4")
                           .arg(inputFile)
                           .arg(track.start, track.end)
                           .arg(err.what())
@@ -85,7 +85,7 @@ void TestFlacon::testDecoder()
     // Checks ___________________________________
     for (int i = 0; i < tracks.count(); ++i) {
         compareAudioHash(
-                QString("%1/%2-flacon.wav").arg(dir()).arg(i + 1, 3, 10, QChar('0')),
+                QStringLiteral("%1/%2-flacon.wav").arg(dir()).arg(i + 1, 3, 10, QChar('0')),
                 tracks.at(i).hash);
     }
 }

--- a/tests/test_format.cpp
+++ b/tests/test_format.cpp
@@ -60,7 +60,7 @@ void TestFlacon::testFormat()
         QFAIL("Can't find format");
 
     if (format->ext() != ext)
-        QFAIL(QString("Incorrect format found:\n    found    '%1',\n    expected '%2' ").arg(format->ext(), ext).toLocal8Bit());
+        QFAIL(QStringLiteral("Incorrect format found:\n    found    '%1',\n    expected '%2' ").arg(format->ext(), ext).toLocal8Bit());
 }
 
 /************************************************
@@ -93,7 +93,7 @@ void TestFlacon::testFormatFromFile()
         QFAIL("Can't find format");
 
     if (format->ext() != ext)
-        QFAIL(QString("Incorrect format found:\n    found    '%1',\n    expected '%2' ").arg(format->ext(), ext).toLocal8Bit());
+        QFAIL(QStringLiteral("Incorrect format found:\n    found    '%1',\n    expected '%2' ").arg(format->ext(), ext).toLocal8Bit());
 }
 
 /************************************************

--- a/tests/test_inputaudiofile.cpp
+++ b/tests/test_inputaudiofile.cpp
@@ -46,7 +46,7 @@ void TestFlacon::testInputAudioFile()
     try {
         InputAudioFile ia(fileName);
         if (!ia.isValid()) {
-            FAIL(QString("Can't open '%1': %2").arg(fileName, ia.errorString()));
+            FAIL(QStringLiteral("Can't open '%1': %2").arg(fileName, ia.errorString()));
             return;
         }
 

--- a/tests/test_loaddiscfromaudio.cpp
+++ b/tests/test_loaddiscfromaudio.cpp
@@ -123,7 +123,7 @@ void TestFlacon::testLoadDiscFromAudioErrors()
 
         QVERIFY(audio.isValid() == false);
         if (!re.match(audio.errorString()).hasMatch()) {
-            QFAIL(QString("Error doesen't match to expected\n\tError:    %1\n\tExpected: %2")
+            QFAIL(QStringLiteral("Error doesen't match to expected\n\tError:    %1\n\tExpected: %2")
                           .arg(audio.errorString(), expected)
                           .toLocal8Bit());
         }

--- a/tests/test_profiles.cpp
+++ b/tests/test_profiles.cpp
@@ -82,7 +82,7 @@ void TestFlacon::testLoadProfiles()
         if (result.value(key).toString() == exp)
             continue;
 
-        QString msg = QString("Compared values are not the same\n\tKey\t%1\n\tActual\t%2\n\tExpected\t%3")
+        QString msg = QStringLiteral("Compared values are not the same\n\tKey\t%1\n\tActual\t%2\n\tExpected\t%3")
                               .arg(key)
                               .arg(result.value(key).toString())
                               .arg(expected.value(key).toString());

--- a/tests/test_textcodecs.cpp
+++ b/tests/test_textcodecs.cpp
@@ -46,7 +46,7 @@ static QByteArray readDataFile(const QString &fileName)
     QFile f(fileName);
 
     if (!f.open(QFile::ReadOnly)) {
-        FAIL(QString("Can't read file %1:\n\t%2").arg(fileName, f.errorString()).toLocal8Bit());
+        FAIL(QStringLiteral("Can't read file %1:\n\t%2").arg(fileName, f.errorString()).toLocal8Bit());
     }
 
     return f.readAll();

--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -42,7 +42,7 @@ char *toString(const DiskState &state)
     }
     // clang-format on
 
-    return qstrdup(QString("Unknown %1").arg(int(state)).toLocal8Bit().constData());
+    return qstrdup(QStringLiteral("Unknown %1").arg(int(state)).toLocal8Bit().constData());
 }
 
 /************************************************

--- a/tests/test_validator.cpp
+++ b/tests/test_validator.cpp
@@ -98,9 +98,9 @@ void TestFlacon::testValidator()
         TcCase spec = loadTestCase(dataDir);
 
         for (auto d : spec.disks) {
-            QFile::copy(QString("%1/%2").arg(dataDir).arg(d.cue.c_str()), QString("%1/%2").arg(dir()).arg(d.cue.c_str()));
+            QFile::copy(QStringLiteral("%1/%2").arg(dataDir).arg(d.cue.c_str()), QStringLiteral("%1/%2").arg(dir()).arg(d.cue.c_str()));
             for (auto a : d.audio) {
-                QFile::copy(QString("%1/%2").arg(dataDir).arg(a.c_str()), QString("%1/%2").arg(dir()).arg(a.c_str()));
+                QFile::copy(QStringLiteral("%1/%2").arg(dataDir).arg(a.c_str()), QStringLiteral("%1/%2").arg(dir()).arg(a.c_str()));
             }
         }
 
@@ -138,7 +138,7 @@ void TestFlacon::testValidator()
             }
 
             if (actual != expected) {
-                QFAIL(QString("Compared errors differ.\n"
+                QFAIL(QStringLiteral("Compared errors differ.\n"
                               "   Actual  : \"%1\"\n"
                               "   Expected: \"%2\"")
                               .arg(actual.join("\", \""), expected.join("\", \""))
@@ -158,7 +158,7 @@ void TestFlacon::testValidator()
             }
 
             if (actual != expected) {
-                QFAIL(QString("Compared warnings differ.\n"
+                QFAIL(QStringLiteral("Compared warnings differ.\n"
                               "   Actual  : \"%1\"\n"
                               "   Expected: \"%2\"")
                               .arg(actual.join("\", \""), expected.join("\", \""))

--- a/tests/testspec.cpp
+++ b/tests/testspec.cpp
@@ -199,11 +199,11 @@ QString TestSpec::findFile(const QString &pattern) const
 {
     QFileInfoList files = mDir.entryInfoList(QStringList(pattern), QDir::Files);
     if (files.count() < 1) {
-        throw FlaconError(QString("%1 file not found").arg(pattern));
+        throw FlaconError(QStringLiteral("%1 file not found").arg(pattern));
     }
 
     if (files.count() > 1) {
-        throw FlaconError(QString("Multipy %1 files found").arg(pattern));
+        throw FlaconError(QStringLiteral("Multipy %1 files found").arg(pattern));
     }
 
     return files.first().filePath();

--- a/tests/tools.cpp
+++ b/tests/tools.cpp
@@ -81,7 +81,7 @@ QString calcAudioHash(const QString &fileName)
         decoder.open(fileName);
     }
     catch (FlaconError &err) {
-        FAIL(QString("Can't open input file '%1': %2").arg(fileName, err.what()).toLocal8Bit());
+        FAIL(QStringLiteral("Can't open input file '%1': %2").arg(fileName, err.what()).toLocal8Bit());
         return "";
     }
 
@@ -138,20 +138,20 @@ void TestCueFile::write()
 {
     QFile f(mFileName);
     if (!f.open(QFile::WriteOnly | QFile::Truncate))
-        QFAIL(QString("Can't create cue file '%1': %2").arg(mFileName).arg(f.errorString()).toLocal8Bit());
+        QFAIL(QStringLiteral("Can't create cue file '%1': %2").arg(mFileName).arg(f.errorString()).toLocal8Bit());
 
     QTextStream cue(&f);
 
-    cue << QString("FILE \"%1\" WAVE\n").arg(mWavFile);
+    cue << QStringLiteral("FILE \"%1\" WAVE\n").arg(mWavFile);
     for (int i = 0; i < mTracks.count(); ++i) {
         TestCueTrack track = mTracks.at(i);
 
-        cue << QString("\nTRACK %1 AUDIO\n").arg(i + 1);
+        cue << QStringLiteral("\nTRACK %1 AUDIO\n").arg(i + 1);
         if (track.index0 != "")
-            cue << QString("  INDEX 00 %1\n").arg(track.index0);
+            cue << QStringLiteral("  INDEX 00 %1\n").arg(track.index0);
 
         if (track.index1 != "")
-            cue << QString("  INDEX 01 %1\n").arg(track.index1);
+            cue << QStringLiteral("  INDEX 01 %1\n").arg(track.index1);
     }
 
     f.close();
@@ -163,7 +163,7 @@ void TestCueFile::write()
 bool compareAudioHash(const QString &file1, const QString &expected)
 {
     if (calcAudioHash(file1) != expected) {
-        FAIL(QString("Compared hases are not the same for:\n"
+        FAIL(QStringLiteral("Compared hases are not the same for:\n"
                      "    [%1] %2\n"
                      "    [%3] %4\n")
 
@@ -203,7 +203,7 @@ void writeHexString(const QString &str, QIODevice *out)
             bool ok;
             n16 = line.mid(i, 2).toShort(&ok, 16);
             if (!ok)
-                throw QString("Incorrect HEX data at %1:\n%2").arg(i).arg(line);
+                throw QStringLiteral("Incorrect HEX data at %1:\n%2").arg(i).arg(line);
 
             out->write(&b, 1);
             i += 2;
@@ -293,7 +293,7 @@ void createWavFile(const QString &fileName, const QString &header, const int dur
         return;
 
     if (!file.open(QFile::WriteOnly | QFile::Truncate))
-        QFAIL(QString("Can't create file '%1': %2").arg(fileName, file.errorString()).toLocal8Bit());
+        QFAIL(QStringLiteral("Can't create file '%1': %2").arg(fileName, file.errorString()).toLocal8Bit());
 
     file.write(wavHdr.buffer());
     file.write("data", 4);
@@ -346,7 +346,7 @@ void createWavFile(const QString &fileName, quint16 bitsPerSample, quint32 sampl
         return;
 
     if (!file.open(QFile::WriteOnly | QFile::Truncate))
-        QFAIL(QString("Can't create file '%1': %2").arg(fileName, file.errorString()).toLocal8Bit());
+        QFAIL(QStringLiteral("Can't create file '%1': %2").arg(fileName, file.errorString()).toLocal8Bit());
 
     file.write(header.toByteArray());
     writeTestWavData(&file, header.dataSize());
@@ -398,7 +398,7 @@ void encodeAudioFile(const QString &wavFileName, const QString &outFileName)
     }
 
     else {
-        QFAIL(QString("Can't create file '%1': unknown file format").arg(outFileName).toLocal8Bit());
+        QFAIL(QStringLiteral("Can't create file '%1': unknown file format").arg(outFileName).toLocal8Bit());
     }
 
     bool     ok = true;
@@ -409,7 +409,7 @@ void encodeAudioFile(const QString &wavFileName, const QString &outFileName)
     ok = ok && (proc.exitStatus() == 0);
 
     if (!ok) {
-        QFAIL(QString("Can't encode %1 %2:")
+        QFAIL(QStringLiteral("Can't encode %1 %2:")
                       .arg(program)
                       .arg(args.join(" "))
                       .toLocal8Bit()
@@ -417,7 +417,7 @@ void encodeAudioFile(const QString &wavFileName, const QString &outFileName)
     }
 
     if (!QFileInfo(outFileName).isFile()) {
-        QFAIL(QString("Can't encode to file '%1' (file don't exists'):")
+        QFAIL(QStringLiteral("Can't encode to file '%1' (file don't exists'):")
                       .arg(outFileName)
                       .toLocal8Bit()
               + proc.readAllStandardError());

--- a/textcodec.cpp
+++ b/textcodec.cpp
@@ -169,13 +169,13 @@ QString TextCodec::decode(const QByteArray &data) const noexcept(false)
 
     iconv_t cd = iconv_open("UTF-16", mName.toLatin1().constData());
     if (cd == (iconv_t)-1) {
-        throw FlaconError(QString("Unable to open iconv_open for %1: %2").arg(mName, strerror(errno)));
+        throw FlaconError(QStringLiteral("Unable to open iconv_open for %1: %2").arg(mName, strerror(errno)));
     }
 
     // int discardIlegalSequence = 1;
     // if (iconvctl(cd, ICONV_SET_DISCARD_ILSEQ, &discardIlegalSequence) == -1) {
     //     iconv_close(cd);
-    //     throw FlaconError(QString("Unable to set ICONV_SET_DISCARD_ILSEQ flag %1: %2").arg(mName, strerror(errno)));
+    //     throw FlaconError(QStringLiteral("Unable to set ICONV_SET_DISCARD_ILSEQ flag %1: %2").arg(mName, strerror(errno)));
     // }
 
     QByteArray out;
@@ -190,7 +190,7 @@ QString TextCodec::decode(const QByteArray &data) const noexcept(false)
     // size_t ok = iconv(cd, &in, &inBytesLeft, &outBuffer, &outBytesLeft);
     //  if (ok == (size_t)-1) {
     //    iconv_close(cd);
-    //    throw FlaconError(QString("Unable to decode for %1: %2 at %3").arg(mName, strerror(errno)).arg(int(in - data.data())));
+    //    throw FlaconError(QStringLiteral("Unable to decode for %1: %2 at %3").arg(mName, strerror(errno)).arg(int(in - data.data())));
     //  }
 
     iconv(cd, &in, &inBytesLeft, &outBuffer, &outBytesLeft);

--- a/types.cpp
+++ b/types.cpp
@@ -167,7 +167,7 @@ QString CueTime::toString(bool cdQuality) const
         int sec = (mCdValue - min * 60 * 75) / 75;
         int frm = mCdValue - (min * 60 + sec) * 75;
 
-        return QString("%1:%2:%3")
+        return QStringLiteral("%1:%2:%3")
                 .arg(min, 2, 10, QChar('0'))
                 .arg(sec, 2, 10, QChar('0'))
                 .arg(frm, 2, 10, QChar('0'));
@@ -177,7 +177,7 @@ QString CueTime::toString(bool cdQuality) const
         int sec  = (mHiValue - min * 60 * 1000) / 1000;
         int msec = mHiValue - (min * 60 + sec) * 1000;
 
-        return QString("%1:%2.%3")
+        return QStringLiteral("%1:%2.%3")
                 .arg(min, 2, 10, QChar('0'))
                 .arg(sec, 2, 10, QChar('0'))
                 .arg(msec, 3, 10, QChar('0'));

--- a/validator/validatorcheckresultorder.cpp
+++ b/validator/validatorcheckresultorder.cpp
@@ -100,5 +100,5 @@ bool ValidatorCheckResultOrder::validateDir(const QString &, const Disk *disk, c
 
 QString ValidatorCheckResultOrder::diskString(const Disk *disk)
 {
-    return QString("%1 \"%2 - %3\"").arg(mDisks.indexOf(disk) + 1).arg(disk->discTag(TagId::Artist), disk->discTag(TagId::Album));
+    return QStringLiteral("%1 \"%2 - %3\"").arg(mDisks.indexOf(disk) + 1).arg(disk->discTag(TagId::Artist), disk->discTag(TagId::Album));
 }


### PR DESCRIPTION
- Qt provides a macro `QStringLiteral()`, which makes constructing QString objects from string literals more efficient.